### PR TITLE
Handle the case when BundleData#getTargetLanguages returns null

### DIFF
--- a/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPDownloadMojo.java
+++ b/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPDownloadMojo.java
@@ -116,9 +116,12 @@ public class GPDownloadMojo extends GPBaseMojo {
                 }
 
                 String bdlSrcLang = bdlData.getSourceLanguage();
+                Set<String> bdlTrgLangs = bdlData.getTargetLanguages();
                 Set<String> bdlLangs = new HashSet<String>();
                 bdlLangs.add(bdlSrcLang);
-                bdlLangs.addAll(bdlData.getTargetLanguages());
+                if (bdlTrgLangs != null) {
+                    bdlLangs.addAll(bdlData.getTargetLanguages());
+                }
 
                 if (!srcLang.equals(bdlSrcLang)) {
                     getLog().warn("The source language of the bundle:" + bundleId


### PR DESCRIPTION
Fixed NPE issue caused by null target languages in GP CLI and maven.

Also fixed a problem in GP CLI copy command, failing to upload empty
resource entries. This problem may occur when source bundle contains a
target language without MT.

Fixes #43.